### PR TITLE
Upgrade rbac api ver

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Use as a dependecies of your Magda deployment:
 
 ## Requirements
 
-Kubernetes: `>= 1.14.0-0`
+Kubernetes: `>= 1.17-0`
 
 ## Values
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Openfaas Helm Chart for Magda
 
-![Version: 5.5.5-magda.1](https://img.shields.io/badge/Version-5.5.5--magda.1-informational?style=flat-square)
+![Version: 5.5.5-magda.2](https://img.shields.io/badge/Version-5.5.5--magda.2-informational?style=flat-square)
 
 Enable Kubernetes as a backend for OpenFaaS (Functions as a Service)
 

--- a/deploy/openfaas/Chart.yaml
+++ b/deploy/openfaas/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Enable Kubernetes as a backend for OpenFaaS (Functions as a Service)
 name: openfaas
-version: 5.5.5-magda.1
+version: 5.5.5-magda.2
 kubeVersion: ">= 1.17-0"
 sources:
   - https://github.com/openfaas/faas

--- a/deploy/openfaas/Chart.yaml
+++ b/deploy/openfaas/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Enable Kubernetes as a backend for OpenFaaS (Functions as a Service)
 name: openfaas
 version: 5.5.5-magda.1
-kubeVersion: ">= 1.14.0-0"
+kubeVersion: ">= 1.17-0"
 sources:
   - https://github.com/openfaas/faas
   - https://github.com/openfaas/faas-netes

--- a/deploy/openfaas/templates/controller-rbac.yaml
+++ b/deploy/openfaas/templates/controller-rbac.yaml
@@ -15,7 +15,7 @@ metadata:
 {{- if .Values.rbac }}
 {{- if .Values.clusterRole }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -74,7 +74,7 @@ rules:
       - list
       - watch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
@@ -95,7 +95,7 @@ subjects:
     namespace: {{ include "openfaas.mainNamespace" . | quote }}
 {{- else }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
@@ -154,7 +154,7 @@ rules:
       - list
       - watch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openfaas-helm-chart",
-  "version": "5.5.5-magda.1",
+  "version": "5.5.5-magda.2",
   "description": "Forked version openfaas Helm Chart for Magda",
   "main": "index.js",
   "repository": "git@github.com:magda-io/openfaas-helm-chart.git",


### PR DESCRIPTION
### What this PR does

Upgrade rbac api ver to rbac.authorization.k8s.io/v1 (removed in k8s 1.22)

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
